### PR TITLE
remove CNAME for docs

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-docs.nervos.org


### PR DESCRIPTION
remove CNAME to fix the issue that docs are not displayed correctly. 