### PR TITLE
Fix codegen for native list

### DIFF
--- a/core/src/main/java/org/nervos/appchain/tx/Contract.java
+++ b/core/src/main/java/org/nervos/appchain/tx/Contract.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Constructor;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -515,6 +516,16 @@ public abstract class Contract extends ManagedTransaction {
             addr = deployedAddresses.get(networkId);
         }
         return addr == null ? getStaticDeployedAddress(networkId) : addr;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static <S extends Type, T>
+            List<T> convertToNative(List<S> arr) {
+        List<T> out = new ArrayList<T>();
+        for (Iterator<S> it = arr.iterator(); it.hasNext(); ) {
+            out.add((T)it.next().getValue());
+        }
+        return out;
     }
 
 }


### PR DESCRIPTION
When generate java class from solidity contract via codeGen, java class defined the datatype in list as native type but actually return solidity type.
This PR is trying to solve the issue that fix the issue by adding a covert function and a for-loop for output parameters.