### PR TITLE
fix make value h256 and tendermint to bft for Android

### DIFF
--- a/core/src/main/java/org/nervos/appchain/protocol/core/methods/request/Transaction.java
+++ b/core/src/main/java/org/nervos/appchain/protocol/core/methods/request/Transaction.java
@@ -37,6 +37,9 @@ public class Transaction {
     private String value;
     private int chainId;
     private final Hash hash = new Hash();
+    private static final BigInteger MAX_VALUE
+            = new BigInteger(
+            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 16);
 
     public Transaction(
             String to, BigInteger nonce, long quota, long validUntilBlock,
@@ -57,10 +60,31 @@ public class Transaction {
             if (value.matches("0[xX][0-9a-fA-F]+")) {
                 this.value = value.substring(2);
             } else {
-                this.value = new BigInteger(value).toString(16);
+                this.value = processValue(value);
             }
         }
 
+    }
+
+    public static String processValue(String value) {
+        String result = "";
+        if (value.matches("0[xX][0-9a-fA-F]+")) {
+            result = value.substring(2);
+        } else if (value == null || value.equals("")) {
+            result = "0";
+        } else {
+            result = new BigInteger(value).toString(16);
+        }
+
+        BigInteger valueBigInt = new BigInteger(result, 16);
+
+        if (Transaction.MAX_VALUE.compareTo(valueBigInt) > 0) {
+            return result;
+        } else {
+            System.out.println("Value you input is out of bound");
+            System.out.println("Value is set as 0");
+            return "0";
+        }
     }
 
     public static Transaction createContractTransaction(
@@ -183,7 +207,7 @@ public class Transaction {
         ByteString bdata = ByteString.copyFrom(strbyte);
 
         byte[] byteValue = ConvertStrByte.hexStringToBytes(
-                Numeric.cleanHexPrefix(getValue()));
+                Numeric.cleanHexPrefix(getValue()), 256);
         ByteString bvalue = ByteString.copyFrom(byteValue);
 
         builder.setData(bdata);

--- a/core/src/main/java/org/nervos/appchain/protocol/core/methods/response/AppBlock.java
+++ b/core/src/main/java/org/nervos/appchain/protocol/core/methods/response/AppBlock.java
@@ -573,7 +573,7 @@ public class AppBlock extends Response<AppBlock.Block> {
                 String gasUsed = headerNode.get("gasUsed").asText();
 
                 //proof tendermint
-                JsonNode proofNode = node.get("header").get("proof").get("Tendermint");
+                JsonNode proofNode = node.get("header").get("proof").get("Bft");
                 String proposal = proofNode.get("proposal").asText();
                 String height = proofNode.get("height").asText();
                 String round = proofNode.get("round").asText();
@@ -581,7 +581,7 @@ public class AppBlock extends Response<AppBlock.Block> {
                 //proof tendermint commits
                 List<TendermintCommit> tendermintCommits = new ArrayList<>();
                 JsonNode commitsNode = node.get("header")
-                        .get("proof").get("Tendermint").get("commits");
+                        .get("proof").get("Bft").get("commits");
                 Iterator<String> commitsAddress = commitsNode.fieldNames();
                 while (commitsAddress.hasNext()) {
                     String commitAddress = commitsAddress.next();

--- a/core/src/test/java/org/nervos/appchain/protocol/core/RawResponseTest.java
+++ b/core/src/test/java/org/nervos/appchain/protocol/core/RawResponseTest.java
@@ -37,7 +37,7 @@ public class RawResponseTest extends ResponseTester {
             + "     \"receiptsRoot\":\"0x918334ef71e85bed370065d1f2758d1eb3f089f7e5323a78a633de7a5f07f371\","
             + "     \"gasUsed\":\"0x132bd\","
             + "     \"proof\":"
-            + "         {\"Tendermint\":{"
+            + "         {\"Bft\":{"
             + "             \"proposal\":\"0xe1b9bba13cb64a920c04f3abc2ea0a98d2db4fb65d233df3afc31c5321bb6054\","
             + "             \"height\":261976,"
             + "             \"round\":0,"

--- a/core/src/test/java/org/nervos/appchain/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/nervos/appchain/protocol/core/ResponseTest.java
@@ -269,7 +269,7 @@ public class ResponseTest extends ResponseTester {
                     + "     \"receiptsRoot\":\"0x918334ef71e85bed370065d1f2758d1eb3f089f7e5323a78a633de7a5f07f371\","
                     + "     \"gasUsed\":\"0x132bd\","
                     + "     \"proof\":"
-                    + "         {\"Tendermint\":{"
+                    + "         {\"Bft\":{"
                     + "             \"proposal\":\"0xe1b9bba13cb64a920c04f3abc2ea0a98d2db4fb65d233df3afc31c5321bb6054\","
                     + "             \"height\":261976,"
                     + "             \"round\":0,"

--- a/protobuf/src/main/java/org/nervos/appchain/protobuf/ConvertStrByte.java
+++ b/protobuf/src/main/java/org/nervos/appchain/protobuf/ConvertStrByte.java
@@ -15,7 +15,14 @@ public class ConvertStrByte {
         return result.toString();
     }
 
-
+    /**
+     * Convert hex string to byte array,
+     * length of byte array is src.length / 2
+     * length of bit of data is src.length * 4
+     *
+     * @param src hex string without "0x"
+     * @return byte array converted from src.
+     */
     public static byte[] hexStringToBytes(String src) {
         src = (src.length() % 2 == 1 ? "0" : "") + src;
         int l = src.length() / 2;
@@ -25,6 +32,34 @@ public class ConvertStrByte {
                     .valueOf(src.substring(i * 2, i * 2 + 2), 16).byteValue();
         }
         return ret;
+    }
+
+    /**
+     * Convert hex string to byte array with fixed bit length
+     *
+     * @param src hex string without "0x"
+     * @param length length of bits of data to be sent to node.
+     * @return byte array converted from src.
+     */
+    public static byte[] hexStringToBytes(String src, int length) {
+        int byteLength = length / 8;
+        if (src.length() > length / 4) {
+            return new byte[byteLength];
+        } else {
+            src = (src.length() % 2 == 1 ? "0" : "") + src;
+            int l = src.length() / 2;
+            byte[] value = new byte[l];
+            for (int i = 0; i < l; i++) {
+                value[i] = (byte) Integer
+                        .valueOf(src.substring(i * 2, i * 2 + 2), 16).byteValue();
+            }
+            int m = byteLength - l;
+            byte[] toAdd = new byte[m];
+            byte[] ret = new byte[byteLength];
+            System.arraycopy(toAdd, 0, ret, 0, m);
+            System.arraycopy(value, 0, ret, m, l);
+            return ret;
+        }
     }
 
 


### PR DESCRIPTION
Change the keyword in appblock from "Tendermint" to "Bft".
Force value to be H256; leading zeros are padded if value does not meet the requirement.