### PR TITLE
check either credential or signature in CitaTxManager

### DIFF
--- a/core/src/main/java/org/nervos/appchain/tx/CitaTransactionManager.java
+++ b/core/src/main/java/org/nervos/appchain/tx/CitaTransactionManager.java
@@ -97,4 +97,12 @@ public class CitaTransactionManager extends TransactionManager {
     public String getFromAddress() {
         return credentials.getAddress();
     }
+
+    public String getFromAddress(boolean isCredential) {
+        if (isCredential) {
+            return credentials.getAddress();
+        } else {
+            return signature.getAddress();
+        }
+    }
 }


### PR DESCRIPTION
Provide an interface to users to indicate either Credential or Signature in which `FromAddress` supposed to be fetched.