### PR TITLE
return signature fromAddr in default method getFromAddress()

### DIFF
--- a/core/src/main/java/org/nervos/appchain/tx/CitaTransactionManager.java
+++ b/core/src/main/java/org/nervos/appchain/tx/CitaTransactionManager.java
@@ -95,7 +95,11 @@ public class CitaTransactionManager extends TransactionManager {
 
     @Override
     public String getFromAddress() {
-        return credentials.getAddress();
+        if (credentials != null) {
+            return credentials.getAddress();
+        } else {
+            return signature.getAddress();
+        }
     }
 
     public String getFromAddress(boolean isCredential) {


### PR DESCRIPTION
make it possible to return fromAddress in CitaTransactionManager. Although there is a method in doing this, this is added in consideration of compatibility.