### PR TITLE
fix issue transaction architecture mismatch when return not full block

### DIFF
--- a/core/src/main/java/org/nervos/appchain/protocol/core/methods/response/AppBlock.java
+++ b/core/src/main/java/org/nervos/appchain/protocol/core/methods/response/AppBlock.java
@@ -612,8 +612,12 @@ public class AppBlock extends Response<AppBlock.Block> {
                 while (txNodes.hasNext()) {
                     JsonNode txNode = txNodes.next();
                     TransactionObject txToAdd = new TransactionObject();
-                    txToAdd.setHash(txNode.get("hash").asText());
-                    txToAdd.setContent(txNode.get("content").asText());
+                    if (txNode.get("hash") == null && txNode.get("content") == null) {
+                        txToAdd.setHash(txNode.asText());
+                    } else {
+                        txToAdd.setHash(txNode.get("hash").asText());
+                        txToAdd.setContent(txNode.get("content").asText());
+                    }
                     transactionObjs.add(txToAdd);
                 }
 


### PR DESCRIPTION
When calling method appGetBlockByNumber() with param returnFullTransaction false to return only hash of transaction, the architecture of returned json is in different architecture. Add check for it to avoid nullPointer exception.