### PR TITLE
Resolve issue 125 add group management methods 

### DIFF
--- a/core/src/main/java/com/cryptape/cita/protocol/system/CITAjSystemContract.java
+++ b/core/src/main/java/com/cryptape/cita/protocol/system/CITAjSystemContract.java
@@ -601,6 +601,50 @@ public class CITAjSystemContract implements CITASystemContract, CITASystemAddres
         return list;
     }
 
+    /**
+     * new group
+     * @see <a href="https://docs.citahub.com/zh-CN/cita/sys-contract-interface/interface#newgroup">newGroup</a>
+     * @param superAdminAddress the address of super_admin
+     * @param groupName the name of group to be created
+     * @param accounts accounts added to the group
+     * @param adminPrivateKey the private key of super_admin
+     * @param version
+     * @param chainId
+     * @return the transaction hash for creating group
+     * @throws IOException
+     */
+    public String newGroup(String superAdminAddress,
+                           String groupName,
+                           List<String> accounts,
+                           String adminPrivateKey,
+                           int version,
+                           BigInteger chainId) throws IOException {
+        // account addresses convert to Address object list
+        List<Address> addresses = new ArrayList<>(accounts.size());
+        for(String acc : accounts){
+            addresses.add(new Address(acc));
+        }
+
+        // groupName string convert to bytes32
+        String nameHex = Util.addUpTo64Hex(ConvertStrByte.stringToHexString(groupName));
+        byte[] nameBytes = ConvertStrByte.hexStringToBytes(Numeric.cleanHexPrefix(nameHex));
+
+        // build input parameters
+        List<Type> inputParameters = Arrays.asList(
+                new Address(superAdminAddress),//origin
+                new Bytes32(nameBytes),//name
+                new DynamicArray<Address>(addresses)//account
+        );
+
+        // encode input parameters
+        String funcData = CITASystemContract.encodeFunction(USER_MANAGER_NEW_GROUP, inputParameters);
+
+        // send request to create group and return transaction hash
+        String txHash = CITASystemContract.sendTxAndGetHash(
+                USER_MANAGER_ADDR, service, adminPrivateKey, funcData, version, chainId);
+        return txHash;
+    }
+
     public Transaction constructStoreTransaction(String data, int version, BigInteger chainId) {
         return new Transaction(
                 STORE_ADDR, Util.getNonce(), DEFAULT_QUOTA,

--- a/tests/src/main/java/com/cryptape/cita/tests/GroupManagerExample.java
+++ b/tests/src/main/java/com/cryptape/cita/tests/GroupManagerExample.java
@@ -1,0 +1,18 @@
+package com.cryptape.cita.tests;
+
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Group and Account Management
+ * If you want to know more about the documentation, please click on the link below.
+ * https://docs.citahub.com/zh-CN/cita/account-permission/account
+ */
+public class GroupManagerExample extends SystemContractExample {
+    public static void main(String[] args) throws IOException {
+        // query groups
+        List<String> groupAddress = sysContract.queryGroups("0xfFFfFFFFFffFFfffFFFFfffffFffffFFfF020009");
+        System.out.println("groupAddress: " + groupAddress);
+    }
+}

--- a/tests/src/main/java/com/cryptape/cita/tests/GroupManagerExample.java
+++ b/tests/src/main/java/com/cryptape/cita/tests/GroupManagerExample.java
@@ -1,7 +1,11 @@
 package com.cryptape.cita.tests;
 
 
+import com.cryptape.cita.protocol.core.methods.response.Log;
+import com.cryptape.cita.protocol.system.CITASystemContract;
+
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -10,9 +14,21 @@ import java.util.List;
  * https://docs.citahub.com/zh-CN/cita/account-permission/account
  */
 public class GroupManagerExample extends SystemContractExample {
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, InterruptedException {
         // query groups
         List<String> groupAddress = sysContract.queryGroups("0xfFFfFFFFFffFFfffFFFFfffffFffffFFfF020009");
         System.out.println("groupAddress: " + groupAddress);
+
+        // create a group
+        String transcationHash = sysContract.newGroup("0xfFFfFFFFFffFFfffFFFFfffffFffffFFfF020009",
+                "newGroup",
+                Arrays.asList("e1c4021742730ded647590a1686d5c4bfcbae0b0", "45a50f45cb81c8aedeab917ea0cd3c9178ebdcae"),
+                adminPriavteKey,
+                version,
+                chainId);
+        System.out.println("transcationHash: " + transcationHash);
+        // get receipt by hash
+        Log log = CITASystemContract.getReceiptLog(service, transcationHash, 0);
+        System.out.println("groupAddress: " + (log == null ? "null" : log.getAddress()));
     }
 }

--- a/tests/src/main/java/com/cryptape/cita/tests/SystemContractExample.java
+++ b/tests/src/main/java/com/cryptape/cita/tests/SystemContractExample.java
@@ -13,6 +13,7 @@ public class SystemContractExample {
     static String adminPriavteKey;
     static int version;
     static BigInteger chainId;
+    static CITAjSystemContract sysContract;
 
     static {
         Config conf = new Config();
@@ -22,11 +23,11 @@ public class SystemContractExample {
         adminPriavteKey = conf.adminPrivateKey;
         version = TestUtil.getVersion(service);
         chainId = TestUtil.getChainId(service);
+        sysContract = new CITAjSystemContract(service);
     }
 
     public static void main(String[] args) throws Exception {
 
-        CITAjSystemContract sysContract = new CITAjSystemContract(service);
         long quotaPrice = sysContract.getQuotaPrice(senderAddr);
         System.out.println("Quota price is: " + quotaPrice);
 

--- a/tests/src/main/java/com/cryptape/cita/tests/SystemContractExample.java
+++ b/tests/src/main/java/com/cryptape/cita/tests/SystemContractExample.java
@@ -69,9 +69,5 @@ public class SystemContractExample {
         //if (setStake) {
         //    System.out.println("success");
         //}
-
-        //test query groups
-        List<String> allGroups = sysContract.queryGroups("0xe2066149012e6c1505e3549d103068bd0f2f0577");
-        System.out.println("addresses of all groups: " + allGroups);
     }
 }


### PR DESCRIPTION
 fix move the initialization of sysControl object to the static block.
add GroupManagerExample and move queryGroup method from SystemContractExample to GroupManagerExample. 
add unit testing of newGroup interface